### PR TITLE
Enable event tracking using custom user id and/or email

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -12,6 +12,8 @@ linter
 JSDoc
 APIs
 CLI
+privateKey
+listId
  - docs/README.md
 klaviyo-node
 klaviyo.track
@@ -24,4 +26,6 @@ Winston.Transport
 logLevel
 apiBasePath
 Param
+klaviyo.suppress
+klaviyo.subscribe
 publicKey

--- a/README.md
+++ b/README.md
@@ -25,25 +25,32 @@ After installing the klaviyo package you can initiate it using your public token
 You can then easily use Klaviyo to track events or identify people.  Note, track and identify requests take your public token.
 
     // Track an event...
-    client.track('Filled out profile', 'someone@mailinator.com', {
+    client.track('Filled out profile', { 
+      '$email': 'someone@mailinator.com',
+      // and/or id
+      // '$id': 'XXXXXXXXXXXX', 
+      }, {
       'Added social accounts': false,
     });
 
     // you can also add profile properties
     client.track(
         'Filled out profile',
-        'someone@mailinator.com',
         {
-          'Added social accounts': false,
+          '$email': someone@mailinator.com',
+          '$first_name': 'Thomas',
+          '$last_name': 'Jefferson'
+          ....
         },
         {
-          '$first_name': 'Thomas',
-          '$last_name': 'Jefferson',
+          'Added social accounts': false,
         }
     );
 
     // ...or just add a property to someone
-    client.identify('thomas.jefferson@mailinator.com', {
+    client.identify({
+      '$email': 'thomas.jefferson@mailinator.com',
+      '$id': 'XXXXXXXXXXXX', 
       '$first_name': 'Thomas',
       '$last_name': 'Jefferson',
       'Plan': 'Premium',

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,7 +56,7 @@ Used to track when someone takes an action or does something.
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | eventName | <code>String</code> |  | The type of Klaviyo request (track/identify) |
-| [customerProperties] | <code>Object</code> | <code>{}</code> | Custom information     including email or id identifier about the person     who did this event. |
+| [customerProperties] | <code>Object</code> | <code>{}</code> | Custom information     including $email or $id identifier about the person     who did this event. |
 | [eventProperties] | <code>Object</code> | <code>{}</code> | Custom information about the person who did this event. |
 
 <a name="module_klaviyo-node..Klaviyo+identify"></a>
@@ -71,5 +71,5 @@ an individual.
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
-| [customerProperties] | <code>Object</code> | <code>{}</code> | Custom information     including email or id identifier about the person     who did this event. |
+| [customerProperties] | <code>Object</code> | <code>{}</code> | Custom information     including $email or $id identifier about the person     who did this event. |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,9 +4,11 @@
 
 * [klaviyo-node](#module_klaviyo-node)
     * [~Klaviyo](#module_klaviyo-node..Klaviyo)
-        * [new Klaviyo(publicKey, [options])](#new_module_klaviyo-node..Klaviyo_new)
+        * [new Klaviyo(publicKey, privateKey, [options])](#new_module_klaviyo-node..Klaviyo_new)
         * [.track(eventName, [customerProperties], [eventProperties])](#module_klaviyo-node..Klaviyo+track) ⇒ <code>Promise</code>
         * [.identify([customerProperties])](#module_klaviyo-node..Klaviyo+identify) ⇒ <code>Promise</code>
+        * [.suppress(email)](#module_klaviyo-node..Klaviyo+suppress) ⇒ <code>Promise</code>
+        * [.subscribe(listId, emails)](#module_klaviyo-node..Klaviyo+subscribe) ⇒ <code>Promise</code>
 
 <a name="module_klaviyo-node..Klaviyo"></a>
 
@@ -28,20 +30,23 @@ here: https://www.klaviyo.com/docs/http-api
 
 
 * [~Klaviyo](#module_klaviyo-node..Klaviyo)
-    * [new Klaviyo(publicKey, [options])](#new_module_klaviyo-node..Klaviyo_new)
+    * [new Klaviyo(publicKey, privateKey, [options])](#new_module_klaviyo-node..Klaviyo_new)
     * [.track(eventName, [customerProperties], [eventProperties])](#module_klaviyo-node..Klaviyo+track) ⇒ <code>Promise</code>
     * [.identify([customerProperties])](#module_klaviyo-node..Klaviyo+identify) ⇒ <code>Promise</code>
+    * [.suppress(email)](#module_klaviyo-node..Klaviyo+suppress) ⇒ <code>Promise</code>
+    * [.subscribe(listId, emails)](#module_klaviyo-node..Klaviyo+subscribe) ⇒ <code>Promise</code>
 
 <a name="new_module_klaviyo-node..Klaviyo_new"></a>
 
-#### new Klaviyo(publicKey, [options])
+#### new Klaviyo(publicKey, privateKey, [options])
 Initialize a new `Klaviyo` with the Klaviyo public key and an
 optional dictionary of `options`.
 
 
 | Param | Type | Description |
 | --- | --- | --- |
-| publicKey | <code>String</code> | The public key that comes with every Klaviyo account. |
+| publicKey | <code>String</code> | The public key for you Klaviyo account. |
+| privateKey | <code>String</code> | The private key for your Klaviyo account. |
 | [options] | <code>Object</code> | (optional) |
 
 <a name="module_klaviyo-node..Klaviyo+track"></a>
@@ -72,4 +77,31 @@ an individual.
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | [customerProperties] | <code>Object</code> | <code>{}</code> | Custom information     including $email or $id identifier about the person     who did this event. |
+
+<a name="module_klaviyo-node..Klaviyo+suppress"></a>
+
+#### klaviyo.suppress(email) ⇒ <code>Promise</code>
+Excludes customer from outbound communications .
+
+**Kind**: instance method of [<code>Klaviyo</code>](#module_klaviyo-node..Klaviyo)  
+**Returns**: <code>Promise</code> - Returns a Promise with the result of the Klaviyo
+    request.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| email | <code>String</code> | Customer email |
+
+<a name="module_klaviyo-node..Klaviyo+subscribe"></a>
+
+#### klaviyo.subscribe(listId, emails) ⇒ <code>Promise</code>
+Subscribes to a list
+
+**Kind**: instance method of [<code>Klaviyo</code>](#module_klaviyo-node..Klaviyo)  
+**Returns**: <code>Promise</code> - Returns a Promise with the result of the Klaviyo
+    request.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| listId | <code>Array.&lt;string&gt;</code> | klaviyo list id |
+| emails | <code>Array.&lt;string&gt;</code> | List of customer emails to subscribe |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,8 +5,8 @@
 * [klaviyo-node](#module_klaviyo-node)
     * [~Klaviyo](#module_klaviyo-node..Klaviyo)
         * [new Klaviyo(publicKey, [options])](#new_module_klaviyo-node..Klaviyo_new)
-        * [.track(eventName, email, [eventProperties], [customerProperties])](#module_klaviyo-node..Klaviyo+track) ⇒ <code>Promise</code>
-        * [.identify(email, [customerProperties])](#module_klaviyo-node..Klaviyo+identify) ⇒ <code>Promise</code>
+        * [.track(eventName, [customerProperties], [eventProperties])](#module_klaviyo-node..Klaviyo+track) ⇒ <code>Promise</code>
+        * [.identify([customerProperties])](#module_klaviyo-node..Klaviyo+identify) ⇒ <code>Promise</code>
 
 <a name="module_klaviyo-node..Klaviyo"></a>
 
@@ -29,8 +29,8 @@ here: https://www.klaviyo.com/docs/http-api
 
 * [~Klaviyo](#module_klaviyo-node..Klaviyo)
     * [new Klaviyo(publicKey, [options])](#new_module_klaviyo-node..Klaviyo_new)
-    * [.track(eventName, email, [eventProperties], [customerProperties])](#module_klaviyo-node..Klaviyo+track) ⇒ <code>Promise</code>
-    * [.identify(email, [customerProperties])](#module_klaviyo-node..Klaviyo+identify) ⇒ <code>Promise</code>
+    * [.track(eventName, [customerProperties], [eventProperties])](#module_klaviyo-node..Klaviyo+track) ⇒ <code>Promise</code>
+    * [.identify([customerProperties])](#module_klaviyo-node..Klaviyo+identify) ⇒ <code>Promise</code>
 
 <a name="new_module_klaviyo-node..Klaviyo_new"></a>
 
@@ -46,7 +46,7 @@ optional dictionary of `options`.
 
 <a name="module_klaviyo-node..Klaviyo+track"></a>
 
-#### klaviyo.track(eventName, email, [eventProperties], [customerProperties]) ⇒ <code>Promise</code>
+#### klaviyo.track(eventName, [customerProperties], [eventProperties]) ⇒ <code>Promise</code>
 Used to track when someone takes an action or does something.
 
 **Kind**: instance method of [<code>Klaviyo</code>](#module_klaviyo-node..Klaviyo)  
@@ -56,13 +56,12 @@ Used to track when someone takes an action or does something.
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | eventName | <code>String</code> |  | The type of Klaviyo request (track/identify) |
-| email | <code>String</code> |  | The email that acts as a unique identified     for this user |
+| [customerProperties] | <code>Object</code> | <code>{}</code> | Custom information     including email or id identifier about the person     who did this event. |
 | [eventProperties] | <code>Object</code> | <code>{}</code> | Custom information about the person who did this event. |
-| [customerProperties] | <code>Object</code> | <code>{}</code> | Custom information about this     event. |
 
 <a name="module_klaviyo-node..Klaviyo+identify"></a>
 
-#### klaviyo.identify(email, [customerProperties]) ⇒ <code>Promise</code>
+#### klaviyo.identify([customerProperties]) ⇒ <code>Promise</code>
 The identify method allows you to identify and set properties on
 an individual.
 
@@ -72,6 +71,5 @@ an individual.
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
-| email | <code>String</code> |  | The email that acts as a unique identified     for this user |
-| [customerProperties] | <code>Object</code> | <code>{}</code> | Custom information about     the person who did this event. |
+| [customerProperties] | <code>Object</code> | <code>{}</code> | Custom information     including email or id identifier about the person     who did this event. |
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,8 @@
 /** @module klaviyo-node */
 const winston = require('winston');
 const {format} = winston;
-const {assign, isUndefined, get} = require('lodash');
+const querystring = require('querystring');
+const {assign, get} = require('lodash');
 const axios = require('axios');
 const assert = require('assert');
 const axiosRetry = require('axios-retry');
@@ -18,8 +19,8 @@ class Klaviyo {
    * optional dictionary of `options`.
    * @constructor
    *
-   * @param {String} publicKey - The public key that comes with every
-   * Klaviyo account.
+   * @param {String} publicKey - The public key for you Klaviyo account.
+   * @param {String} privateKey - The private key for your Klaviyo account.
    * @param {Object} [options] (optional)
    *   @property {Winston.Transport} transport (default: Console) - A
    *       Winston Logger Transport object. When a Transport is passed, all
@@ -32,12 +33,13 @@ class Klaviyo {
    *   @property {String} apiBasePath (default: https://a.klaviyo.com/api) -
    *       The base URL to which to send the track and identify calls to.
    */
-  constructor(publicKey, options) {
+  constructor(publicKey, privateKey, options) {
     options = options || {};
 
     assert(publicKey, 'You must pass your Klaviyo public key.');
 
     this.publicKey = publicKey;
+    this.privateKey = privateKey;
 
     const defaultTransport = new winston.transports.Console({
       format: winston.format.combine(
@@ -113,51 +115,50 @@ class Klaviyo {
     return false;
   }
 
+
   /**
-   * A helper function that sends data to Klaviyo. This is used by the
-   * track and identify function to send the events.
+   * A helper function that sends data to Klaviyo.
    * @private
-   * @param {String} verb - The type of Klaviyo request (track/identify)
-   * @param {Object} data - An object that represents the Klaviyo event
-   * @return {String} - The string "foo"
+   * @param {String} apiVersion - Klaviyo api version
+   * @param {String} path - request path
+   * @param {String} params - request parameters
+   * @param {Object} data - request data
+   * @param {String} method - request type
+   * @return {Promise} Returns a Promise which resolves to
+   *    response data or rejects
    */
-  _requestKlaviyo(verb, data) {
-    assert(verb === 'identify' || verb === 'track', `${verb} is not a \
-      supported Klaviyo even type`);
-
-    assert(!isUndefined(data), `_requestKlaviyo can't be called without \
-      an event object`);
-    const endpoint = `${this.apiBasePath}/${verb}`;
-    data['token'] = this.publicKey;
-    const payload = Buffer.from(JSON.stringify(data)).toString('base64');
-
+  _requestKlaviyo(apiVersion, path, params, data, method = 'get') {
+    const endpoint =
+      `${this.apiBasePath}${apiVersion ? `/${apiVersion}/` : '/'}${path}`;
     this.logger.log('info', endpoint);
+
     return new Promise((resolve, reject) => {
-      axios({
-        method: 'get',
+      const requestParameter = {
+        method,
         url: endpoint,
-        params: {
-          'data': payload,
-        },
+        ...(params ? {params}: {}),
+        ...(data ? {data}: {}),
+      };
+
+      axios(requestParameter).then((response) => {
+        if (response.data === 0) {
+          this.logger.log('warn', `Klaviyo rejected the \
+            track request`);
+        } else {
+          this.logger.log('verbose', `Successfully sent request to \
+            Klaviyo`);
+        }
+        resolve(response.data);
       })
-          .then((response) => {
-            if (response.data === 0) {
-              this.logger.log('warn', `Klaviyo rejected the \
-                track request`, data);
-            } else {
-              this.logger.log('verbose', `Successfully sent an event to \
-                Klaviyo`, data);
-            }
-            resolve(response.data);
-          })
           .catch((error) => {
             const status = get(error, 'response.status', 'Unkown Status');
             this.logger.log('error', `Encountered ${status} \
-              from GET to ${endpoint}`, payload);
+          from GET to ${endpoint}`, params);
             reject(error);
           });
     });
   }
+
 
   /**
    * Used to track when someone takes an action or does something.
@@ -182,21 +183,15 @@ class Klaviyo {
       'customer_properties': customerProperties,
     };
 
-    return this._requestKlaviyo('track', data);
+    data['token'] = this.publicKey;
+    const payload = Buffer.from(JSON.stringify(data)).toString('base64');
+    const params = {
+      'data': payload,
+    };
+
+    return this._requestKlaviyo(undefined, 'track', params);
   }
 
-  /**
-   *
-   *
-   * @param {Object} [customerProperties={}] - Custom information
-   *     including $email or $id identifier about the person
-   *     who did this event.
-   * @memberof Klaviyo
-   */
-  ensureIdentifier(customerProperties) {
-    assert(customerProperties.$email || customerProperties.$id,
-        'No identifier ($email or $id) found in customerProperties');
-  }
 
   /**
    * The identify method allows you to identify and set properties on
@@ -218,7 +213,89 @@ class Klaviyo {
       'properties': prepedCustomerProperites,
     };
 
-    return this._requestKlaviyo('identify', data);
+
+    data['token'] = this.publicKey;
+    const payload = Buffer.from(JSON.stringify(data)).toString('base64');
+    const params = {
+      'data': payload,
+    };
+
+    return this._requestKlaviyo(undefined, 'identify', params);
+  }
+
+
+  /**
+   * Excludes customer from outbound communications .
+   * @param {String} email - Customer email
+   * @return {Promise} Returns a Promise with the result of the Klaviyo
+   *     request.
+   */
+  suppress(email) {
+    assert(!!email, 'Email is required');
+    this.ensurePrivateKey();
+
+    this.logger.log('verbose', `Sending Klaviyo an exclusion request \
+      for user ${email}`);
+
+    // Data needs to be transmitted as form-urlencoded
+    const data = querystring.stringify({
+      api_key: this.privateKey,
+      email,
+    });
+
+    return this._requestKlaviyo('v1', 'people/exclusions', null, data, 'post');
+  }
+
+
+  /**
+   * Subscribes to a list
+   * @param {Array<string>} listId - klaviyo list id
+   * @param {Array<string>} emails - List of customer emails to subscribe
+   * @return {Promise} Returns a Promise with the result of the Klaviyo
+   *     request.
+   */
+  subscribe(listId, emails) {
+    assert(!!listId, 'listId is required');
+    assert(emails && emails.length, 'Parmeter emails is not valid array');
+    this.ensurePrivateKey();
+
+    this.logger.log('verbose', `Sending Klaviyo an exclusion request \
+      for users ${emails}`);
+
+    const data = {
+      api_key: this.privateKey,
+      profiles: emails.filter((e) => e).map((email) => ({email})),
+    };
+
+    return this._requestKlaviyo('v2',
+        `list/${listId}/subscribe`, null, data, 'post');
+  }
+
+
+  /**
+   * Ensures costomer properties incldue an identifier (id or email)
+   *
+   * @param {Object} [customerProperties={}] - Custom information
+   *     including $email or $id identifier about the person
+   *     who did this event.
+   * @memberof Klaviyo
+   */
+  ensureIdentifier(customerProperties) {
+    assert(customerProperties.$email || customerProperties.$id,
+        'No identifier ($email or $id) found in customerProperties');
+  }
+
+
+  /**
+   * Validates Klaviyo private key
+   *
+   * @param {Object} [customerProperties={}] - Custom information
+   *     including $email or $id identifier about the person
+   *     who did this event.
+   * @memberof Klaviyo
+   */
+  ensurePrivateKey() {
+    assert(this.privateKey, 'Klaviyo private key not set');
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -162,49 +162,79 @@ class Klaviyo {
   /**
    * Used to track when someone takes an action or does something.
    * @param {String} eventName - The type of Klaviyo request (track/identify)
-   * @param {String} email - The email that acts as a unique identified
-   *     for this user
+   * @param {Object} [customerProperties={}] - Custom information
+   *     including email or id identifier about the person
+   *     who did this event.
    * @param {Object} [eventProperties={}] - Custom information about the
    * person who did this event.
-   * @param {Object} [customerProperties={}] - Custom information about this
-   *     event.
    * @return {Promise} Returns a Promise with the result of the Klaviyo
    *     request.
    */
-  track(eventName, email, eventProperties={}, customerProperties={}) {
-    this.logger.log('verbose', `Sending Klaviyo a track event ${eventName} \
-      for user ${email}`);
-    assert(email, 'You must pass an email value.');
+  track(eventName, customerProperties = {}, eventProperties = {}) {
+    const prepedCustomerProperites =
+      this.prepCutomerProperties(customerProperties);
 
-    customerProperties['$email'] = email;
+    this.logger.log('verbose', `Sending Klaviyo a track event ${eventName} \
+      for user ${prepedCustomerProperites.$id ||
+      prepedCustomerProperites.$email}`);
+
     const data = {
       'event': eventName,
       'properties': eventProperties,
-      'customer_properties': customerProperties,
+      'customer_properties': prepedCustomerProperites,
     };
 
     return this._requestKlaviyo('track', data);
   }
 
   /**
+   *
+   *
+   * @param {Object} [customerProperties={}] - Custom information
+   *     including email or id identifier about the person
+   *     who did this event.
+   * @return {Object} Returns object with id and email properties
+   *     converted to $id and $email properties
+   * @memberof Klaviyo
+   */
+  prepCutomerProperties(customerProperties) {
+    assert(customerProperties.email || customerProperties.id,
+        'No identifier (email or id) found in customerProperties');
+
+    const prepedCustomerProperites = {
+      ...customerProperties,
+    };
+
+    if (prepedCustomerProperites.email) {
+      prepedCustomerProperites['$email'] = prepedCustomerProperites.email;
+      delete prepedCustomerProperites.email;
+    }
+    if (prepedCustomerProperites.id) {
+      prepedCustomerProperites['$id'] = prepedCustomerProperites.id;
+      delete prepedCustomerProperites.id;
+    }
+    return prepedCustomerProperites;
+  }
+
+  /**
    * The identify method allows you to identify and set properties on
    * an individual.
-   * @param {String} email - The email that acts as a unique identified
-   *     for this user
-   * @param {Object} [customerProperties={}] - Custom information about
-   *     the person who did this event.
+   * @param {Object} [customerProperties={}] - Custom information
+   *     including email or id identifier about the person
+   *     who did this event.
    * @return {Promise} Returns a Promise with the result of the Klaviyo
    *     request.
    */
-  identify(email, customerProperties={}) {
-    this.logger.log('verbose', `Sending Klaviyo an identify event \
-      for user ${email}`);
-    assert(email, 'You must pass an email value.');
+  identify(customerProperties = {}) {
+    const prepedCustomerProperites =
+      this.prepCutomerProperties(customerProperties);
 
-    customerProperties['$email'] = email;
+    this.logger.log('verbose', `Sending Klaviyo an identify event \
+      for user ${prepedCustomerProperites.$id ||
+      prepedCustomerProperites.$email}`);
 
     const data = {
-      'properties': customerProperties,
+      'properties': prepedCustomerProperites,
     };
 
     return this._requestKlaviyo('identify', data);

--- a/lib/index.js
+++ b/lib/index.js
@@ -163,7 +163,7 @@ class Klaviyo {
    * Used to track when someone takes an action or does something.
    * @param {String} eventName - The type of Klaviyo request (track/identify)
    * @param {Object} [customerProperties={}] - Custom information
-   *     including email or id identifier about the person
+   *     including $email or $id identifier about the person
    *     who did this event.
    * @param {Object} [eventProperties={}] - Custom information about the
    * person who did this event.
@@ -171,17 +171,15 @@ class Klaviyo {
    *     request.
    */
   track(eventName, customerProperties = {}, eventProperties = {}) {
-    const prepedCustomerProperites =
-      this.prepCutomerProperties(customerProperties);
-
+    this.ensureIdentifier(customerProperties);
     this.logger.log('verbose', `Sending Klaviyo a track event ${eventName} \
-      for user ${prepedCustomerProperites.$id ||
-      prepedCustomerProperites.$email}`);
+      for user ${customerProperties.$id ||
+      customerProperties.$email}`);
 
     const data = {
       'event': eventName,
       'properties': eventProperties,
-      'customer_properties': prepedCustomerProperites,
+      'customer_properties': customerProperties,
     };
 
     return this._requestKlaviyo('track', data);
@@ -191,43 +189,26 @@ class Klaviyo {
    *
    *
    * @param {Object} [customerProperties={}] - Custom information
-   *     including email or id identifier about the person
+   *     including $email or $id identifier about the person
    *     who did this event.
-   * @return {Object} Returns object with id and email properties
-   *     converted to $id and $email properties
    * @memberof Klaviyo
    */
-  prepCutomerProperties(customerProperties) {
-    assert(customerProperties.email || customerProperties.id,
-        'No identifier (email or id) found in customerProperties');
-
-    const prepedCustomerProperites = {
-      ...customerProperties,
-    };
-
-    if (prepedCustomerProperites.email) {
-      prepedCustomerProperites['$email'] = prepedCustomerProperites.email;
-      delete prepedCustomerProperites.email;
-    }
-    if (prepedCustomerProperites.id) {
-      prepedCustomerProperites['$id'] = prepedCustomerProperites.id;
-      delete prepedCustomerProperites.id;
-    }
-    return prepedCustomerProperites;
+  ensureIdentifier(customerProperties) {
+    assert(customerProperties.$email || customerProperties.$id,
+        'No identifier ($email or $id) found in customerProperties');
   }
 
   /**
    * The identify method allows you to identify and set properties on
    * an individual.
    * @param {Object} [customerProperties={}] - Custom information
-   *     including email or id identifier about the person
+   *     including $email or $id identifier about the person
    *     who did this event.
    * @return {Promise} Returns a Promise with the result of the Klaviyo
    *     request.
    */
   identify(customerProperties = {}) {
-    const prepedCustomerProperites =
-      this.prepCutomerProperties(customerProperties);
+    this.ensureIdentifier(customerProperties);
 
     this.logger.log('verbose', `Sending Klaviyo an identify event \
       for user ${prepedCustomerProperites.$id ||

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -3,22 +3,29 @@ Klaviyo = require('./');
 const ensurIdentiferErrMsg =
   'No identifier ($email or $id) found in customerProperties';
 
-test('Require a write key', () => {
-  expect(() =>
-    new Klaviyo()
-  ).toThrowError(new Error('You must pass your Klaviyo public key.'));
+describe('#constructor', () => {
+  test('Require a write key', () => {
+    expect(() =>
+      new Klaviyo()
+    ).toThrowError(new Error('You must pass your Klaviyo public key.'));
+  });
 });
 
-test('Require customer identier ($id or $email) for track', () => {
-  expect(() =>
-    (new Klaviyo('fake key')).track()
-  ).toThrowError(new Error(ensurIdentiferErrMsg));
+
+describe('#track', () => {
+  test('Require customer identier ($id or $email) for track', () => {
+    expect(() =>
+      (new Klaviyo('fake key')).track()
+    ).toThrowError(new Error(ensurIdentiferErrMsg));
+  });
 });
 
-test('Require customer identier ($id or $email) for identify', () => {
-  expect(() =>
-    (new Klaviyo('fake key')).identify()
-  ).toThrowError(new Error(ensurIdentiferErrMsg));
+describe('#identify', () => {
+  test('Require customer identier ($id or $email) for identify', () => {
+    expect(() =>
+      (new Klaviyo('fake key')).identify()
+    ).toThrowError(new Error(ensurIdentiferErrMsg));
+  });
 });
 
 describe('#ensureIdentifier', () => {
@@ -56,5 +63,13 @@ describe('#ensureIdentifier', () => {
     expect(() =>
       klaviyo.ensureIdentifier(customerProperties)
     ).toThrowError(new Error(ensurIdentiferErrMsg));
+  });
+});
+
+describe('#ensurePrivateKey', () => {
+  test('Throws if no private key is set', () => {
+    expect(() =>
+      (new Klaviyo('fake key')).ensurePrivateKey()
+    ).toThrowError(new Error('Klaviyo private key not set'));
   });
 });

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -1,49 +1,60 @@
 Klaviyo = require('./');
 
+const ensurIdentiferErrMsg =
+  'No identifier ($email or $id) found in customerProperties';
+
 test('Require a write key', () => {
   expect(() =>
     new Klaviyo()
   ).toThrowError(new Error('You must pass your Klaviyo public key.'));
 });
 
-test('Require an email for track', () => {
-  const errMsg = 'No identifier (email or id) found in customerProperties';
+test('Require customer identier ($id or $email) for track', () => {
   expect(() =>
     (new Klaviyo('fake key')).track()
-  ).toThrowError(new Error(errMsg));
+  ).toThrowError(new Error(ensurIdentiferErrMsg));
 });
 
-test('Require an email for identify', () => {
-  const errMsg = 'No identifier (email or id) found in customerProperties';
+test('Require customer identier ($id or $email) for identify', () => {
   expect(() =>
     (new Klaviyo('fake key')).identify()
-  ).toThrowError(new Error(errMsg));
+  ).toThrowError(new Error(ensurIdentiferErrMsg));
 });
 
-describe('#prepCutomerProperties', () => {
+describe('#ensureIdentifier', () => {
   let klaviyo;
   beforeAll(() => {
     klaviyo = new Klaviyo('fake key');
   });
 
-  test('Returns prepped customer properties as expected', () => {
-    const customerProperties = {
-      email: 'test@test.com',
-      id: '13134',
+  test('Verifies customer identifiers as expected', () => {
+    let customerProperties = {
+      $email: 'test@test.com',
+      $id: '13134',
     };
-    const prepCutomerProperties =
-      klaviyo.prepCutomerProperties(customerProperties);
-    expect(prepCutomerProperties.email).toBeFalsy();
-    expect(prepCutomerProperties.$email).toBeTruthy();
-    expect(prepCutomerProperties.id).toBeFalsy();
-    expect(prepCutomerProperties.$id).toBeTruthy();
+    expect(() =>
+      klaviyo.ensureIdentifier(customerProperties)
+    ).not.toThrowError();
+
+    customerProperties = {
+      $id: '13134',
+    };
+    expect(() =>
+      klaviyo.ensureIdentifier(customerProperties)
+    ).not.toThrowError();
+
+    customerProperties = {
+      $email: 'test@test.com',
+    };
+    expect(() =>
+      klaviyo.ensureIdentifier(customerProperties)
+    ).not.toThrowError();
   });
 
   test('Throws if no identifier is found', () => {
     const customerProperties = {};
-    const errMsg = 'No identifier (email or id) found in customerProperties';
     expect(() =>
-      klaviyo.prepCutomerProperties(customerProperties)
-    ).toThrowError(new Error(errMsg));
+      klaviyo.ensureIdentifier(customerProperties)
+    ).toThrowError(new Error(ensurIdentiferErrMsg));
   });
 });

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -7,13 +7,43 @@ test('Require a write key', () => {
 });
 
 test('Require an email for track', () => {
+  const errMsg = 'No identifier (email or id) found in customerProperties';
   expect(() =>
     (new Klaviyo('fake key')).track()
-  ).toThrowError(new Error('You must pass an email value.'));
+  ).toThrowError(new Error(errMsg));
 });
 
 test('Require an email for identify', () => {
+  const errMsg = 'No identifier (email or id) found in customerProperties';
   expect(() =>
     (new Klaviyo('fake key')).identify()
-  ).toThrowError(new Error('You must pass an email value.'));
+  ).toThrowError(new Error(errMsg));
+});
+
+describe('#prepCutomerProperties', () => {
+  let klaviyo;
+  beforeAll(() => {
+    klaviyo = new Klaviyo('fake key');
+  });
+
+  test('Returns prepped customer properties as expected', () => {
+    const customerProperties = {
+      email: 'test@test.com',
+      id: '13134',
+    };
+    const prepCutomerProperties =
+      klaviyo.prepCutomerProperties(customerProperties);
+    expect(prepCutomerProperties.email).toBeFalsy();
+    expect(prepCutomerProperties.$email).toBeTruthy();
+    expect(prepCutomerProperties.id).toBeFalsy();
+    expect(prepCutomerProperties.$id).toBeTruthy();
+  });
+
+  test('Throws if no identifier is found', () => {
+    const customerProperties = {};
+    const errMsg = 'No identifier (email or id) found in customerProperties';
+    expect(() =>
+      klaviyo.prepCutomerProperties(customerProperties)
+    ).toThrowError(new Error(errMsg));
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "klaviyo-node",
-  "version": "1.0.6",
+  "version": "1.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This PR address #10 by doing the following:

- Consolidate user properties on `identity` and `track`  for simplicity 
- Adds support for custom user id  on user properties parameter
- Updates test and ensure they pass
- Updates API doc in README.md 